### PR TITLE
switch to libphonenumber for country list and prefixes

### DIFF
--- a/Signal-Windows/ViewModels/AddContactPageViewModel.cs
+++ b/Signal-Windows/ViewModels/AddContactPageViewModel.cs
@@ -126,7 +126,7 @@ namespace Signal_Windows.ViewModels
                         if (originalNumber[0] != '+')
                         {
                             // need a better way of determining the "default" country code here
-                            var formattedPhoneNumber = PhoneNumberFormatter.formatE164("1", originalNumber);
+                            var formattedPhoneNumber = PhoneNumberFormatter.FormatE164("1", originalNumber);
                             if (string.IsNullOrEmpty(formattedPhoneNumber))
                             {
                                 ContactNumber = originalNumber;

--- a/Signal-Windows/ViewModels/RegisterPageViewModel.cs
+++ b/Signal-Windows/ViewModels/RegisterPageViewModel.cs
@@ -12,13 +12,15 @@ using Windows.UI.Xaml.Controls;
 using Windows.UI.Core;
 using libsignalservice.util;
 using Windows.UI.Popups;
+using PhoneNumbers;
 
 namespace Signal_Windows.ViewModels
 {
     public class RegisterPageViewModel : ViewModelBase
     {
         public CancellationTokenSource CancelSource = new CancellationTokenSource();
-        public IEnumerable<string> CountriesList { get; set; } = CountryArrays.Names;
+        public List<string> CountriesList { get; set; } = new List<string>(250);
+        private List<int> CountriesPrefixList { get; set; } = new List<int>(250);
         public RegisterPage View { get; set; }
         public string FinalNumber { get; set; }
         private string _PhonePrefix { get; set; }
@@ -35,12 +37,29 @@ namespace Signal_Windows.ViewModels
             }
         }
 
+        public RegisterPageViewModel()
+        {
+            HashSet<string> set = PhoneNumberUtil.GetInstance().GetSupportedRegions();
+            var phoneUtil = PhoneNumberUtil.GetInstance();
+            foreach (var region in set)
+            {
+                if(region != "AC" && region != "SX" && region != "CW" && region != "BQ" && region != "TA" && region != "SS")
+                {
+                    string s = new Locale("en", region).GetDisplayCountry("en");
+                    int prefix = phoneUtil.GetCountryCodeForRegion(region);
+                    CountriesList.Add(s);
+                    CountriesPrefixList.Add(prefix);
+                }
+            }
+        }
+
         internal void RegisterPage_Loaded()
         {
             var c = Windows.System.UserProfile.GlobalizationPreferences.HomeGeographicRegion;
-            for (int i = 0; i < CountryArrays.Abbreviations.Length; i++)
+            for (int i=0;i<CountriesPrefixList.Count;i++)
             {
-                if (CountryArrays.Abbreviations[i] == c)
+                int prefix = CountriesPrefixList[i];
+                if (prefix == PhoneNumberUtil.GetInstance().GetCountryCodeForRegion(c))
                 {
                     View.SetCountry(i);
                 }
@@ -65,7 +84,7 @@ namespace Signal_Windows.ViewModels
         {
             try
             {
-                string number = PhoneNumberFormatter.formatE164(PhonePrefix, PhoneSuffix);
+                string number = PhoneNumberFormatter.FormatE164(PhonePrefix, PhoneSuffix);
                 if(number != null && number.Length > 0 && number[0] == '+')
                 {
                     FinalNumber = number;
@@ -104,8 +123,10 @@ namespace Signal_Windows.ViewModels
 
         public void ComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            int index = (sender as ComboBox).SelectedIndex;
-            PhonePrefix = Utils.GetCountryCode(CountryArrays.Abbreviations[index]);
+            ComboBox dropdown = (ComboBox)sender;
+            string region = (string)dropdown.SelectedItem;
+            int prefix = CountriesPrefixList[dropdown.SelectedIndex];
+            PhonePrefix = "+" + prefix;
         }
     }
 }

--- a/Signal-Windows/project.json
+++ b/Signal-Windows/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "libsignal-service-dotnet": "1.5.6",
+    "libsignal-service-dotnet": "1.5.6.1",
     "Microsoft.EntityFrameworkCore": "1.1.2",
     "Microsoft.EntityFrameworkCore.Design": "1.1.2",
     "Microsoft.EntityFrameworkCore.Sqlite": "1.1.2",


### PR DESCRIPTION
libphonenumber has some support for listing supported countries/regions, but this PR has ugly problems:

- the performance is hideous. When constructing the RegisterPageViewModel, S-W stalls for several seconds
- the country list is ordered by the country code and not name, and thus appears unordered. Manually ordering would make the performance even worse

Though i am not sure if the country arrays in Utils have a similar performance impact which hits during startup and thus is not directly noticeable. We could speed up things by building the lists in parallel with multiple worker tasks on startup, but i am not sure how that will work out on weak machines.