### PR TITLE
use events to update the conversation list items from the model

### DIFF
--- a/Signal-Windows/Controls/ConversationListElement.xaml.cs
+++ b/Signal-Windows/Controls/ConversationListElement.xaml.cs
@@ -1,4 +1,5 @@
 using Signal_Windows.Models;
+using System;
 using System.ComponentModel;
 using System.Diagnostics;
 using Windows.UI.Xaml;
@@ -79,20 +80,31 @@ namespace Signal_Windows.Controls
         {
             if (Model != null)
             {
-                Model.View = this;
+                Model.UpdateUI += Model_UpdateUI;
                 ConversationDisplayName.Text = Model.ThreadDisplayName;
                 UnreadCount = Model.UnreadCount;
                 LastMessage = Model.LastMessage?.Content.Content;
             }
+            else
+            {
+                Debug.WriteLine("ConversationListElement datacontext changed to null");
+            }
         }
 
-        public void UpdateConversationDisplay(SignalConversation thread)
+        private void Model_UpdateUI(object sender, EventArgs e)
         {
-            Model.ThreadDisplayName = thread.ThreadDisplayName;
-            Model.LastActiveTimestamp = thread.LastActiveTimestamp;
-            ConversationDisplayName.Text = thread.ThreadDisplayName;
-            UnreadCount = thread.UnreadCount;
-            LastMessage = Model.LastMessage?.Content.Content;
+            var conversation = (SignalConversation)sender;
+            if (Model != null && Model == conversation)
+            {
+                ConversationDisplayName.Text = Model.ThreadDisplayName;
+                UnreadCount = Model.UnreadCount;
+                LastMessage = Model.LastMessage?.Content.Content;
+            }
+            else
+            {
+                Debug.WriteLine("Model_UpdateUI: stale update event received");
+                conversation.UpdateUI -= Model_UpdateUI;
+            }
         }
     }
 }

--- a/Signal-Windows/Models/SignalConversation.cs
+++ b/Signal-Windows/Models/SignalConversation.cs
@@ -1,10 +1,13 @@
 using Signal_Windows.Controls;
+using System;
 using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Signal_Windows.Models
 {
     public class SignalConversation
     {
+        public event EventHandler UpdateUI;
+
         public long Id { get; set; }
         public string ThreadId { get; set; }
         public string ThreadDisplayName { get; set; }
@@ -18,6 +21,10 @@ namespace Signal_Windows.Models
         public SignalMessage LastMessage { get; set; }
         public long? LastSeenMessageId { get; set; }
         public SignalMessage LastSeenMessage { get; set; }
-        [NotMapped] public ConversationListElement View;
+
+        internal void Update()
+        {
+            UpdateUI?.Invoke(this, new EventArgs());
+        }
     }
 }

--- a/Signal-Windows/ViewModels/MainPageViewModel.cs
+++ b/Signal-Windows/ViewModels/MainPageViewModel.cs
@@ -98,7 +98,9 @@ namespace Signal_Windows.ViewModels
         {
             SignalConversation uiThread = ThreadsDictionary[thread.ThreadId];
             uiThread.CanReceive = thread.CanReceive;
-            uiThread.View.UpdateConversationDisplay(thread);
+            uiThread.ThreadDisplayName = thread.ThreadDisplayName;
+            uiThread.LastActiveTimestamp = thread.LastActiveTimestamp;
+            uiThread.Update();
             if (SelectedThread == uiThread)
             {
                 View.Thread.Update(thread);
@@ -282,7 +284,8 @@ namespace Signal_Windows.ViewModels
                         View.Thread.Append(message);
                         View.Thread.ScrollToBottom();
                         SelectedThread.LastMessage = message;
-                        SelectedThread.View.UpdateConversationDisplay(SelectedThread);
+                        SelectedThread.LastActiveTimestamp = now;
+                        SelectedThread.Update();
                         MoveThreadToTop(SelectedThread);
                         await Task.Run(() =>
                         {
@@ -394,7 +397,7 @@ namespace Signal_Windows.ViewModels
                 thread.LastActiveTimestamp = message.ReceivedTimestamp;
                 thread.LastMessage = message;
                 thread.LastMessageId = message.Id;
-                thread.View.UpdateConversationDisplay(thread);
+                thread.Update();
                 MoveThreadToTop(thread);
             }
             Debug.WriteLine("incoming lock released");
@@ -404,8 +407,8 @@ namespace Signal_Windows.ViewModels
         {
             SignalConversation uiConversation = ThreadsDictionary[conversation.ThreadId];
             uiConversation.UnreadCount = 0;
-            uiConversation.View.UnreadCount = 0;
             uiConversation.LastSeenMessageId = conversation.LastMessageId;
+            uiConversation.Update();
         }
 
         public void UIUpdateMessageBox(SignalMessage updatedMessage)
@@ -433,7 +436,7 @@ namespace Signal_Windows.ViewModels
                     }
                     thread.LastMessage = message;
                     thread.LastMessageId = message.Id;
-                    thread.View.UpdateConversationDisplay(thread);
+                    thread.Update();
                 }
             }
             Debug.WriteLine("IKChange lock released");


### PR DESCRIPTION
This should fix #70.

We add an event to the model, listen to it in the view, and if the view receives an event from a model not equal to its datacontext it discards it and removes the stale event handler.

Will test this as soon as there are enough pending messages, hopefully this evening.