### PR TITLE
Virtualized unreadmarker

### DIFF
--- a/Signal-Windows/Controls/Conversation.xaml
+++ b/Signal-Windows/Controls/Conversation.xaml
@@ -12,37 +12,16 @@
     d:DesignWidth="400">
 
     <Control.Resources>
-        <Style TargetType="ListBoxItem" x:Key="NormalMessageStyle">
-            <Setter Property="Template">
-                <Setter.Value>
-                    <ControlTemplate TargetType="ListBoxItem">
-                        <local:Message x:Name="ListBoxItemContent" />
-                    </ControlTemplate>
-                </Setter.Value>
-            </Setter>
-        </Style>
-        <Style TargetType="ListBoxItem" x:Key="UnreadMarkerStyle">
-            <Setter Property="Template">
-                <Setter.Value>
-                    <ControlTemplate TargetType="ListBoxItem">
-                        <local:UnreadMarker />
-                    </ControlTemplate>
-                </Setter.Value>
-            </Setter>
-        </Style>
-        <Style TargetType="ListBoxItem" x:Key="IdentityKeyChangeStyle">
-            <Setter Property="Template">
-                <Setter.Value>
-                    <ControlTemplate TargetType="ListBoxItem">
-                        <local:IdentityKeyChangeMessage />
-                    </ControlTemplate>
-                </Setter.Value>
-            </Setter>
-        </Style>
+        <DataTemplate x:Key="NormalMessageTemplate" x:DataType="models:SignalMessage">
+            <local:Message x:Name="ListBoxItemContent" />
+        </DataTemplate>
+        <DataTemplate x:Key="UnreadMarkerTemplate">
+            <local:UnreadMarker />
+        </DataTemplate>
         <DataTemplate x:Key="IdentityKeyChangeTemplate">
             <local:IdentityKeyChangeMessage />
         </DataTemplate>
-        <local:MessageStyleSelector x:Key="MessageDataStyleSelector" NormalMessage="{StaticResource NormalMessageStyle}" UnreadMarker="{StaticResource UnreadMarkerStyle}" IdentityKeyChangeMessage="{StaticResource IdentityKeyChangeStyle}" />
+        <local:MessageTemplateSelector  x:Key="MessageDataTemplateSelector" NormalMessage="{StaticResource NormalMessageTemplate}" UnreadMarker="{StaticResource UnreadMarkerTemplate}" IdentityKeyChangeMessage="{StaticResource IdentityKeyChangeTemplate}" />
     </Control.Resources>
     <Grid Background="White">
         <Grid.RowDefinitions>
@@ -57,7 +36,16 @@
                 <TextBlock Name="Username" IsTextSelectionEnabled="True" HorizontalAlignment="Center" Text="{x:Bind ThreadUsername, Mode=OneWay}" Visibility="{x:Bind ThreadUsernameVisibility, Mode=OneWay}" />
             </StackPanel>
         </Border>
-        <ListBox Grid.Row="1" Name="ConversationItemsControl" VirtualizingStackPanel.VirtualizationMode="Recycling" Background="White" ScrollViewer.VerticalScrollBarVisibility="Visible" Padding="0 0 15 0" ItemContainerStyleSelector="{StaticResource MessageDataStyleSelector}" />
+        <ListView Grid.Row="1" Name="ConversationItemsControl" VirtualizingStackPanel.VirtualizationMode="Recycling" Background="White" ScrollViewer.VerticalScrollBarVisibility="Visible" Padding="0 0 15 0" ItemTemplateSelector="{StaticResource MessageDataTemplateSelector}" SelectionMode="None">
+            <ListView.ItemContainerStyle>
+                <Style TargetType="ListViewItem">
+                    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                </Style>
+            </ListView.ItemContainerStyle>
+            <ListView.Style>
+                <Style TargetType="ListView" />
+            </ListView.Style>
+        </ListView>
         <Grid Grid.Row="2" BorderBrush="{ThemeResource TextBoxBorderThemeBrush}" BorderThickness="0,1,0,0">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*"/>

--- a/Signal-Windows/Controls/Conversation.xaml
+++ b/Signal-Windows/Controls/Conversation.xaml
@@ -42,9 +42,6 @@
                     <Setter Property="HorizontalContentAlignment" Value="Stretch" />
                 </Style>
             </ListView.ItemContainerStyle>
-            <ListView.Style>
-                <Style TargetType="ListView" />
-            </ListView.Style>
         </ListView>
         <Grid Grid.Row="2" BorderBrush="{ThemeResource TextBoxBorderThemeBrush}" BorderThickness="0,1,0,0">
             <Grid.ColumnDefinitions>

--- a/Signal-Windows/Controls/IdentityKeyChangeMessage.xaml.cs
+++ b/Signal-Windows/Controls/IdentityKeyChangeMessage.xaml.cs
@@ -25,11 +25,11 @@ namespace Signal_Windows.Controls
             this.InitializeComponent();
             DataContextChanged += IdentityKeyChangeMessage_DataContextChanged;
         }
-        public SignalMessage Model
+        public SignalMessageContainer Model
         {
             get
             {
-                return this.DataContext as SignalMessage;
+                return this.DataContext as SignalMessageContainer;
             }
             set
             {
@@ -41,7 +41,7 @@ namespace Signal_Windows.Controls
         {
             if (Model != null)
             {
-                MessageTextBlock.Text = Model.Content.Content;
+                MessageTextBlock.Text = Model.Message.Content.Content;
             }
             else
             {

--- a/Signal-Windows/Controls/Message.xaml.cs
+++ b/Signal-Windows/Controls/Message.xaml.cs
@@ -75,7 +75,7 @@ namespace Signal_Windows.Controls
                     CheckImage.Visibility = Visibility.Collapsed;
                     DoubleCheckImage.Visibility = Visibility.Collapsed;
                     ResendTextBlock.Visibility = Visibility.Collapsed;
-                    if (Model.Message.ThreadId[0] != '+')
+                    if (Model.Message.ThreadId.EndsWith("="))
                     {
                         MessageAuthor.Visibility = Visibility.Visible;
                         MessageAuthor.Text = Model.Message.Author.ThreadDisplayName;

--- a/Signal-Windows/Controls/Message.xaml.cs
+++ b/Signal-Windows/Controls/Message.xaml.cs
@@ -104,7 +104,7 @@ namespace Signal_Windows.Controls
 
         private void ResendTextBlock_Tapped(object sender, Windows.UI.Xaml.Input.TappedRoutedEventArgs e)
         {
-            throw new NotImplementedException();
+            App.ViewModels.MainPageInstance.OutgoingQueue.Add(Model.Message);
         }
 
         internal bool HandleUpdate(SignalMessage updatedMessage)

--- a/Signal-Windows/Controls/Message.xaml.cs
+++ b/Signal-Windows/Controls/Message.xaml.cs
@@ -18,7 +18,7 @@ namespace Signal_Windows.Controls
         {
             get
             {
-                return (SignalMessageContainer) this.DataContext;
+                return DataContext as SignalMessageContainer;
             }
             set
             {
@@ -99,7 +99,6 @@ namespace Signal_Windows.Controls
 
         private void MessageBox_DataContextChanged(FrameworkElement sender, DataContextChangedEventArgs args)
         {
-
             UpdateUI();
         }
 

--- a/Signal-Windows/Controls/UnreadMarker.xaml.cs
+++ b/Signal-Windows/Controls/UnreadMarker.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices.WindowsRuntime;
@@ -23,6 +24,7 @@ namespace Signal_Windows.Controls
         {
             this.InitializeComponent();
             DataContextChanged += UnreadMarker_DataContextChanged;
+            UnreadText.Text = "keks";
         }
 
         public SignalUnreadMarker Model
@@ -35,7 +37,6 @@ namespace Signal_Windows.Controls
 
         private void UnreadMarker_DataContextChanged(FrameworkElement sender, DataContextChangedEventArgs args)
         {
-            Model.View = this;
         }
 
         public void SetText(string text)

--- a/Signal-Windows/Controls/UnreadMarker.xaml.cs
+++ b/Signal-Windows/Controls/UnreadMarker.xaml.cs
@@ -24,7 +24,6 @@ namespace Signal_Windows.Controls
         {
             this.InitializeComponent();
             DataContextChanged += UnreadMarker_DataContextChanged;
-            UnreadText.Text = "keks";
         }
 
         public SignalUnreadMarker Model
@@ -37,6 +36,10 @@ namespace Signal_Windows.Controls
 
         private void UnreadMarker_DataContextChanged(FrameworkElement sender, DataContextChangedEventArgs args)
         {
+            if (Model != null)
+            {
+                UnreadText.Text = Model.Text;
+            }
         }
 
         public void SetText(string text)

--- a/Signal-Windows/Controls/VirtualizedMessagesCollection.cs
+++ b/Signal-Windows/Controls/VirtualizedMessagesCollection.cs
@@ -25,6 +25,7 @@ namespace Signal_Windows.Controls
 
     public class SignalUnreadMarker
     {
+        public string Text = "";
     }
 
     public class VirtualizedCollection : IList, INotifyCollectionChanged
@@ -42,6 +43,7 @@ namespace Signal_Windows.Controls
             if (Conversation.LastSeenMessageIndex > 0 && Conversation.LastSeenMessageIndex < Conversation.MessagesCount )
             {
                 UnreadMarkerIndex = (int) Conversation.LastSeenMessageIndex;
+                UnreadMarker.Text = Conversation.UnreadCount > 1 ? $"{Conversation.UnreadCount} new messages" : "1 new message";
             }
             else
             {

--- a/Signal-Windows/Controls/VirtualizedMessagesCollection.cs
+++ b/Signal-Windows/Controls/VirtualizedMessagesCollection.cs
@@ -1,4 +1,5 @@
-﻿using Signal_Windows.Models;
+
+using Signal_Windows.Models;
 using Signal_Windows.Storage;
 using System;
 using System.Collections;
@@ -22,16 +23,30 @@ namespace Signal_Windows.Controls
         }
     }
 
+    public class SignalUnreadMarker
+    {
+    }
+
     public class VirtualizedCollection : IList, INotifyCollectionChanged
     {
         private readonly static int PAGE_SIZE = 50;
         public event NotifyCollectionChangedEventHandler CollectionChanged;
         private Dictionary<int, IList<SignalMessageContainer>> Cache = new Dictionary<int, IList<SignalMessageContainer>>();
         private SignalConversation Conversation;
+        private SignalUnreadMarker UnreadMarker = new SignalUnreadMarker();
+        public int UnreadMarkerIndex = -1;
 
         public VirtualizedCollection(SignalConversation c)
         {
             Conversation = c;
+            if (Conversation.LastSeenMessageIndex > 0 && Conversation.LastSeenMessageIndex < Conversation.MessagesCount )
+            {
+                UnreadMarkerIndex = (int) Conversation.LastSeenMessageIndex;
+            }
+            else
+            {
+                UnreadMarkerIndex = -1;
+            }
         }
 
         private static int GetPageIndex(int itemIndex)
@@ -44,24 +59,61 @@ namespace Signal_Windows.Controls
         {
             get
             {
-                int inpageIndex = index % PAGE_SIZE;
-                int pageIndex = GetPageIndex(index);
-                if (!Cache.ContainsKey(pageIndex))
+                if (UnreadMarkerIndex > 0)
                 {
-                    Debug.WriteLine($"cache miss {pageIndex}");
-                    Cache[pageIndex] = SignalDBContext.GetMessagesLocked(Conversation, pageIndex * PAGE_SIZE, PAGE_SIZE);
+                    if (index < UnreadMarkerIndex)
+                    {
+                        return Get(index);
+                    }
+                    else if (index == UnreadMarkerIndex)
+                    {
+                        return UnreadMarker;
+                    }
+                    else
+                    {
+                        return Get(index - 1);
+                    }
                 }
-                var page = Cache[pageIndex];
-                return page[inpageIndex];
+                else
+                {
+                    return Get(index);
+                }
             }
             set => throw new NotImplementedException();
+        }
+
+        private SignalMessageContainer Get(int index)
+        {
+            int inpageIndex = index % PAGE_SIZE;
+            int pageIndex = GetPageIndex(index);
+            if (!Cache.ContainsKey(pageIndex))
+            {
+                Debug.WriteLine($"cache miss {pageIndex}");
+                Cache[pageIndex] = SignalDBContext.GetMessagesLocked(Conversation, pageIndex * PAGE_SIZE, PAGE_SIZE);
+            }
+            var page = Cache[pageIndex];
+            var item = page[inpageIndex];
+            return page[inpageIndex];
         }
 
         public bool IsFixedSize => false;
 
         public bool IsReadOnly => false;
 
-        public int Count => (int)Conversation.MessagesCount;
+        public int Count
+        {
+            get
+            {
+                if (UnreadMarkerIndex > 0)
+                {
+                    return (int)Conversation.MessagesCount + 1;
+                }
+                else
+                {
+                    return (int)Conversation.MessagesCount;
+                }
+            }
+        }
 
         public bool IsSynchronized => false;
 
@@ -70,12 +122,18 @@ namespace Signal_Windows.Controls
         /// <summary>
         /// "Adds" a SignalMessageContainer to this virtualized collection.</summary>
         /// <remarks>
-        /// The method may (if incoming) or may not (if outgoing) already be present in the database, so we explicitly insert at the correct position in the cache line.
+        /// The message may (if incoming) or may not (if outgoing) already be present in the database, so we explicitly insert at the correct position in the cache line.
         /// Count is mapped to the SignalConversation's MessagesCount, so callers must update appropriately before calling this method, and no async method must be called in between.</remarks>
         /// <param name="value">The object to add to the VirtualizedMessagesCollection.</param>
         /// <returns>The position into which the new element was inserted, or -1 to indicate that the item was not inserted into the collection.</returns>
-        public int Add(object value)
+        public int Add(object value, bool forcedScroll)
         {
+            if (forcedScroll && UnreadMarkerIndex > 0)
+            {
+                var old = UnreadMarkerIndex;
+                UnreadMarkerIndex = -1;
+                CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, UnreadMarker, old));
+            }
             var message = value as SignalMessageContainer;
             int inpageIndex = message.Index % PAGE_SIZE;
             int pageIndex = GetPageIndex(message.Index);
@@ -85,11 +143,9 @@ namespace Signal_Windows.Controls
                 Cache[pageIndex] = SignalDBContext.GetMessagesLocked(Conversation, pageIndex * PAGE_SIZE, PAGE_SIZE);
             }
             Cache[pageIndex].Insert(inpageIndex, message);
-            if (Cache[pageIndex].IndexOf(message) != inpageIndex  || message.Index != Count-1)
-            {
-                throw new InvalidOperationException("VirtualizedCollection is in an inconsistent state!");
-            }
-            CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, message, message.Index));
+            int virtualIndex = GetVirtualIndex(message.Index);
+            Debug.WriteLine($"NotifyCollectionChangedAction.Add index={message.Index} virtualIndex={virtualIndex}");
+            CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, message, virtualIndex));
             return message.Index;
         }
 
@@ -115,13 +171,38 @@ namespace Signal_Windows.Controls
 
         public int IndexOf(object value)
         {
-            SignalMessageContainer smc = value as SignalMessageContainer;
-            if (smc != null)
+            if (value is SignalMessageContainer)
             {
-                Debug.WriteLine($"IndexOf returning {smc.Index}");
-                return smc.Index;
+                SignalMessageContainer smc = (SignalMessageContainer) value;
+                return GetVirtualIndex(smc.Index);
             }
-            return -1;
+            else if (value is SignalUnreadMarker)
+            {
+                return UnreadMarkerIndex;
+            }
+            else
+            {
+                return -1;
+            }
+        }
+
+        internal int GetVirtualIndex(int rawIndex)
+        {
+            if (UnreadMarkerIndex > 0)
+            {
+                if (rawIndex < UnreadMarkerIndex)
+                {
+                    return rawIndex;
+                }
+                else
+                {
+                    return rawIndex + 1;
+                }
+            }
+            else
+            {
+                return rawIndex;
+            }
         }
 
         public void Insert(int index, object value)
@@ -135,6 +216,11 @@ namespace Signal_Windows.Controls
         }
 
         public void RemoveAt(int index)
+        {
+            throw new NotImplementedException();
+        }
+
+        public int Add(object value)
         {
             throw new NotImplementedException();
         }

--- a/Signal-Windows/Controls/VirtualizedMessagesCollection.cs
+++ b/Signal-Windows/Controls/VirtualizedMessagesCollection.cs
@@ -30,7 +30,7 @@ namespace Signal_Windows.Controls
 
     public class VirtualizedCollection : IList, INotifyCollectionChanged
     {
-        private readonly static int PAGE_SIZE = 50;
+        private const int PAGE_SIZE = 50;
         public event NotifyCollectionChangedEventHandler CollectionChanged;
         private Dictionary<int, IList<SignalMessageContainer>> Cache = new Dictionary<int, IList<SignalMessageContainer>>();
         private SignalConversation Conversation;

--- a/Signal-Windows/Migrations/SignalDB/20170901124533_m3.Designer.cs
+++ b/Signal-Windows/Migrations/SignalDB/20170901124533_m3.Designer.cs
@@ -9,9 +9,10 @@ using Signal_Windows.Models;
 namespace Signal_Windows.Migrations
 {
     [DbContext(typeof(SignalDBContext))]
-    partial class SignalDBContextModelSnapshot : ModelSnapshot
+    [Migration("20170901124533_m3")]
+    partial class m3
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
             modelBuilder
                 .HasAnnotation("ProductVersion", "1.1.2");

--- a/Signal-Windows/Migrations/SignalDB/20170901124533_m3.cs
+++ b/Signal-Windows/Migrations/SignalDB/20170901124533_m3.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Signal_Windows.Migrations
+{
+    public partial class m3 : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<long>(
+                name: "LastSeenMessageIndex",
+                table: "SignalConversation",
+                nullable: false,
+                defaultValue: 0L);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "LastSeenMessageIndex",
+                table: "SignalConversation");
+        }
+    }
+}

--- a/Signal-Windows/Models/SignalConversation.cs
+++ b/Signal-Windows/Models/SignalConversation.cs
@@ -17,7 +17,7 @@ namespace Signal_Windows.Models
         public uint ExpiresInSeconds { get; set; }
         public long? LastMessageId { get; set; }
         public SignalMessage LastMessage { get; set; }
-        public long? LastSeenMessageId { get; set; }
+        public long LastSeenMessageIndex { get; set; }
         public SignalMessage LastSeenMessage { get; set; }
         [NotMapped] public ConversationListElement View;
     }

--- a/Signal-Windows/Signal-Windows.csproj
+++ b/Signal-Windows/Signal-Windows.csproj
@@ -174,6 +174,10 @@
     <Compile Include="Migrations\SignalDB\20170825082857_m2.designer.cs">
       <DependentUpon>20170825082857_m2.cs</DependentUpon>
     </Compile>
+    <Compile Include="Migrations\SignalDB\20170901124533_m3.cs" />
+    <Compile Include="Migrations\SignalDB\20170901124533_m3.designer.cs">
+      <DependentUpon>20170901124533_m3.cs</DependentUpon>
+    </Compile>
     <Compile Include="Migrations\SignalDB\SignalDBContextModelSnapshot.cs" />
     <Compile Include="Models\SignalEarlyReceipt.cs" />
     <Compile Include="Models\SignalIdentity.cs" />

--- a/Signal-Windows/Signal/OutgoingMessages.cs
+++ b/Signal-Windows/Signal/OutgoingMessages.cs
@@ -41,7 +41,7 @@ namespace Signal_Windows.ViewModels
                         ExpiresInSeconds = (int)outgoingSignalMessage.ExpiresAt
                     };
 
-                    if (outgoingSignalMessage.ThreadId[0] == '+')
+                    if (!outgoingSignalMessage.ThreadId.EndsWith("="))
                     {
                         if (!token.IsCancellationRequested)
                         {

--- a/Signal-Windows/Storage/DB.cs
+++ b/Signal-Windows/Storage/DB.cs
@@ -757,7 +757,7 @@ namespace Signal_Windows.Storage
                     {
                         timestamp = message.ComposedTimestamp;
                     }
-                    if (message.ThreadId.StartsWith("+"))
+                    if (!message.ThreadId.EndsWith("="))
                     {
                         var contact = ctx.Contacts
                             .Where(c => c.ThreadId == message.ThreadId)
@@ -909,7 +909,7 @@ namespace Signal_Windows.Storage
             {
                 using (var ctx = new SignalDBContext())
                 {
-                    if (thread.ThreadId.StartsWith("+"))
+                    if (!thread.ThreadId.EndsWith("="))
                     {
                         var contact = ctx.Contacts
                             .Where(c => c.ThreadId == thread.ThreadId)

--- a/Signal-Windows/Utils.cs
+++ b/Signal-Windows/Utils.cs
@@ -86,24 +86,6 @@ namespace Signal_Windows
             }
         }
 
-        public static T FindParent<T>(FrameworkElement reference)
-  where T : FrameworkElement
-        {
-            FrameworkElement parent = reference;
-            while (parent != null)
-            {
-                parent = parent.Parent as FrameworkElement;
-
-                var rc = parent as T;
-                if (rc != null)
-                {
-                    return rc;
-                }
-            }
-
-            return null;
-        }
-
         public static int CalculateDefaultColorIndex(string title)
         {
             if (title.Length == 0)

--- a/Signal-Windows/ViewModels/MainPageViewModel.cs
+++ b/Signal-Windows/ViewModels/MainPageViewModel.cs
@@ -374,6 +374,13 @@ namespace Signal_Windows.ViewModels
                     if (message.Direction == SignalMessageDirection.Synced)
                     {
                         View.Thread.AddToOutgoingMessagesCache(container);
+                        unreadCount = 0;
+                        thread.LastSeenMessageIndex = thread.MessagesCount;
+                    }
+                    else
+                    {
+                        //TODO don't increase unread if we did scroll automatically, and mark the message as seen
+                        unreadCount++;
                     }
                 }
                 else

--- a/Signal-Windows/ViewModels/MainPageViewModel.cs
+++ b/Signal-Windows/ViewModels/MainPageViewModel.cs
@@ -242,11 +242,6 @@ namespace Signal_Windows.ViewModels
                         SelectedThread = (SignalConversation)e.AddedItems[0];
                         View.Thread.Load(SelectedThread);
                         View.SwitchToStyle(View.GetCurrentViewStyle());
-                        SignalConversation conversation = await Task.Run(() =>
-                        {
-                            return SignalDBContext.ClearUnreadLocked(SelectedThread.ThreadId);
-                        });
-                        UIResetRead(conversation);
                     }
                     Debug.WriteLine("SelectionChanged lock released");
                 }
@@ -293,23 +288,21 @@ namespace Signal_Windows.ViewModels
 
                         /* update in-memory data */
                         SelectedThread.MessagesCount += 1;
-                        //View.Thread.RemoveUnreadMarker();
+                        SelectedThread.UnreadCount = 0;
+                        SelectedThread.LastMessage = message;
+                        SelectedThread.LastSeenMessageIndex = SelectedThread.MessagesCount;
+                        SelectedThread.View.UpdateConversationDisplay(SelectedThread);
                         var container = new SignalMessageContainer(message, (int)SelectedThread.MessagesCount - 1);
                         View.Thread.Append(container, true);
-                        SelectedThread.LastMessage = message;
-                        SelectedThread.View.UpdateConversationDisplay(SelectedThread);
                         MoveThreadToTop(SelectedThread);
 
                         /* save to disk */
                         await Task.Run(() =>
                         {
                             SignalDBContext.SaveMessageLocked(message);
-                            SignalDBContext.ClearUnreadLocked(SelectedThread.ThreadId);
                         });
 
-                        /* update in-memory data with db results */
-                        SelectedThread.LastMessageId = message.Id;
-                        SelectedThread.LastSeenMessageId = message.Id;
+                        /* add to OutgoingCache */
                         View.Thread.AddToOutgoingMessagesCache(container);
 
                         /* send */
@@ -373,7 +366,6 @@ namespace Signal_Windows.ViewModels
                 {
                     SignalDBContext.SaveMessageLocked(message);
                 });
-                long? seenId = null;
                 thread.MessagesCount += 1;
                 if (SelectedThread == thread)
                 {
@@ -383,7 +375,6 @@ namespace Signal_Windows.ViewModels
                     {
                         View.Thread.AddToOutgoingMessagesCache(container);
                     }
-                    seenId = message.Id;
                 }
                 else
                 {
@@ -394,34 +385,16 @@ namespace Signal_Windows.ViewModels
                     else if (message.Direction == SignalMessageDirection.Synced)
                     {
                         unreadCount = 0;
-                        thread.LastSeenMessageId = message.Id;
-                        seenId = message.Id;
+                        thread.LastSeenMessageIndex = thread.MessagesCount;
                     }
-                }
-                await Task.Run(() =>
-                {
-                    SignalDBContext.UpdateConversationLocked(message.ThreadId, unreadCount, seenId);
-                });
-                if (message.Read)
-                {
-                    thread.LastSeenMessageId = message.Id;
                 }
                 thread.UnreadCount = unreadCount;
                 thread.LastActiveTimestamp = message.ReceivedTimestamp;
                 thread.LastMessage = message;
-                thread.LastMessageId = message.Id;
                 thread.View.UpdateConversationDisplay(thread);
                 MoveThreadToTop(thread);
             }
             Debug.WriteLine("incoming lock released");
-        }
-
-        public void UIResetRead(SignalConversation conversation)
-        {
-            SignalConversation uiConversation = ThreadsDictionary[conversation.ThreadId];
-            uiConversation.UnreadCount = 0;
-            uiConversation.View.UnreadCount = 0;
-            uiConversation.LastSeenMessageId = conversation.LastMessageId;
         }
 
         public void UIUpdateMessageBox(SignalMessage updatedMessage)
@@ -449,7 +422,6 @@ namespace Signal_Windows.ViewModels
                         View.Thread.Append(container, false);
                     }
                     thread.LastMessage = message;
-                    thread.LastMessageId = message.Id;
                     thread.View.UpdateConversationDisplay(thread);
                 }
             }

--- a/Signal-Windows/project.json
+++ b/Signal-Windows/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "libsignal-service-dotnet": "2.5.10.2",
+    "libsignal-service-dotnet": "2.5.10.3",
     "Microsoft.EntityFrameworkCore": "1.1.2",
     "Microsoft.EntityFrameworkCore.Design": "1.1.2",
     "Microsoft.EntityFrameworkCore.Sqlite": "1.1.2",


### PR DESCRIPTION
Basic unread markers for the virtualized collection! Unread state is currently only changed by composing a message and receiving a sync message. Will refine this in a few days, but that involves reacting to scrolling and should go into a separate PR.

Note: This PR includes a database migration, and 2 minor unrelated bugfixes.

cc @golf1052