### PR TITLE
disable virtualization of the conversation list

### DIFF
--- a/Signal-Windows/Views/MainPage.xaml
+++ b/Signal-Windows/Views/MainPage.xaml
@@ -38,6 +38,11 @@
                 </Button>
                 <AutoSuggestBox Grid.Row="1" Margin="16"/>
                 <ListView Grid.Row="2" Name="ContactsList" ItemsSource="{x:Bind Vm.Threads}" SelectionMode="Single" SelectionChanged="ContactsList_SelectionChanged">
+                    <ListView.ItemsPanel>
+                        <ItemsPanelTemplate>
+                            <StackPanel></StackPanel>
+                        </ItemsPanelTemplate>
+                    </ListView.ItemsPanel>
                     <ListView.ItemContainerStyle>
                         <Style TargetType="ListViewItem">
                             <Setter Property="HorizontalContentAlignment" Value="Stretch" />


### PR DESCRIPTION
When the conversation list grows large, it uses virtualization tweaks to reduce the memory usage. This breaks our assumptions about the 1-to-1 relations between the conversation control and the actual conversation, so we might be better off with disabling it for now.

Fixes #70