### PR TITLE
Get country/region code from current culture name

### DIFF
--- a/Signal-Windows/Utils.cs
+++ b/Signal-Windows/Utils.cs
@@ -143,10 +143,10 @@ namespace Signal_Windows
             }
         }
 
-        public static string GetCountryCode()
+        public static string GetCountryISO()
         {
-            var c = CultureInfo.CurrentCulture.TwoLetterISOLanguageName;
-            return GetCountryCode(c.ToUpper());
+            var c = CultureInfo.CurrentCulture.Name;
+            return c.Substring(c.Length - 2);
         }
 
         public static bool ContainsCaseInsensitive(this string str, string value)

--- a/Signal-Windows/ViewModels/AddContactPageViewModel.cs
+++ b/Signal-Windows/ViewModels/AddContactPageViewModel.cs
@@ -130,7 +130,7 @@ namespace Signal_Windows.ViewModels
                 {
                     contactAnnotationList = contactAnnotationLists[0];
                 }
-
+                
                 foreach (var contact in contacts)
                 {
                     var phones = contact.Phones;
@@ -333,9 +333,7 @@ namespace Signal_Windows.ViewModels
         /// <returns>A number in E164 format</returns>
         private string ParsePhoneNumber(string number)
         {
-            // on phone we should try to get their SIM country code
-            // otherwise we should try to use the user's location?
-            PhoneNumber phoneNumber = phoneNumberUtil.Parse(number, "US");
+            PhoneNumber phoneNumber = phoneNumberUtil.Parse(number, Utils.GetCountryISO());
             return phoneNumberUtil.Format(phoneNumber, PhoneNumberFormat.E164);
         }
     }


### PR DESCRIPTION
Using the last 2 letters from the culture name to get the ISO alpha-2 country/region code. I find this more reliable than just using the language name.