### PR TITLE
Set the status bar colour on mobile

### DIFF
--- a/Signal-Windows/App.xaml.cs
+++ b/Signal-Windows/App.xaml.cs
@@ -112,6 +112,14 @@ namespace Signal_Windows
                 LaunchActivatedEventArgs args = e as LaunchActivatedEventArgs;
                 if (args.PrelaunchActivated == false)
                 {
+                    if (Windows.Foundation.Metadata.ApiInformation.IsTypePresent("Windows.UI.ViewManagement.StatusBar"))
+                    {
+                        var sb = Windows.UI.ViewManagement.StatusBar.GetForCurrentView();
+                        sb.BackgroundColor = Windows.UI.Color.FromArgb(1, 0x20, 0x90, 0xEA);
+                        sb.BackgroundOpacity = 1;
+                        sb.ForegroundColor = Windows.UI.Colors.White;
+                    }
+
                     if (rootFrame.Content == null)
                     {
                         // Wenn der Navigationsstapel nicht wiederhergestellt wird, zur ersten Seite navigieren

--- a/Signal-Windows/Signal-Windows.csproj
+++ b/Signal-Windows/Signal-Windows.csproj
@@ -347,6 +347,11 @@
       <Version>2.2.9</Version>
     </PackageReference>
   </ItemGroup>
+  <ItemGroup>
+    <SDKReference Include="WindowsMobile, Version=10.0.16299.0">
+      <Name>Windows Mobile Extensions for the UWP</Name>
+    </SDKReference>
+  </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>
   </PropertyGroup>


### PR DESCRIPTION
Set the status bar background colour to the splash screen background colour and set the foreground colour to white.

![signal wp_ss_20171022_0001](https://user-images.githubusercontent.com/13038188/31864677-82e74bbe-b759-11e7-8e2a-d0dfcf5fc77d.png)
