### PR TITLE
restrict multiwindows to one per virtual desktop for now

### DIFF
--- a/Signal-Windows.Lib/SignalLibHandle.cs
+++ b/Signal-Windows.Lib/SignalLibHandle.cs
@@ -72,13 +72,13 @@ namespace Signal_Windows.Lib
 
         public void RemoveFrontend(CoreDispatcher d)
         {
-            Logger.LogTrace("AddFrontend() locking");
+            Logger.LogTrace("RemoveFrontend() locking");
             SemaphoreSlim.Wait(CancelSource.Token);
-            Logger.LogTrace("AddFrontend() locked");
+            Logger.LogTrace("RemoveFrontend() locked");
             Logger.LogInformation("Unregistering frontend of dispatcher {0}", d.GetHashCode());
             Frames.Remove(d);
             SemaphoreSlim.Release();
-            Logger.LogTrace("AddFrontend() released");
+            Logger.LogTrace("RemoveFrontend() released");
         }
 
         public void PurgeAccountData()

--- a/Signal-Windows/Views/MainPage.xaml
+++ b/Signal-Windows/Views/MainPage.xaml
@@ -37,7 +37,7 @@
                     <TextBlock Text="+" FontSize="34" FontWeight="Light" Foreground="{ThemeResource ApplicationPageBackgroundThemeBrush}"/>
                 </Button>
                 <AutoSuggestBox Grid.Row="1" Margin="16"/>
-                <ListView Grid.Row="2" Name="ContactsList" ItemsSource="{x:Bind Vm.Conversations, Mode=TwoWay}" SelectionMode="Single" SelectionChanged="ContactsList_SelectionChanged">
+                <ListView Grid.Row="2" Name="ContactsList" ItemsSource="{x:Bind Vm.Conversations, Mode=TwoWay}" SelectionMode="Single" SelectionChanged="Vm.ConversationsList_SelectionChanged" SelectedItem="{x:Bind Vm.SelectedConversation, Mode=TwoWay}">
                     <ListView.ItemsPanel>
                         <ItemsPanelTemplate>
                             <StackPanel></StackPanel>

--- a/Signal-Windows/Views/MainPage.xaml.cs
+++ b/Signal-Windows/Views/MainPage.xaml.cs
@@ -1,3 +1,5 @@
+using libsignalservice;
+using Microsoft.Extensions.Logging;
 using Signal_Windows.Controls;
 using Signal_Windows.Lib;
 using Signal_Windows.Models;
@@ -22,6 +24,7 @@ namespace Signal_Windows
     /// </summary>
     public sealed partial class MainPage : Page
     {
+        private readonly ILogger Logger = LibsignalLogging.CreateLogger<MainPage>();
         public MainPage()
         {
             this.InitializeComponent();
@@ -78,6 +81,7 @@ namespace Signal_Windows
 
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
+            Vm.RequestedConversationId = e.Parameter as string;
             UpdateLayout();
             SwitchToStyle(GetCurrentViewStyle());
             MainPanel.DisplayMode = SplitViewDisplayMode.CompactInline;
@@ -121,18 +125,6 @@ namespace Signal_Windows
             get
             {
                 return ConversationControl;
-            }
-        }
-
-        private void ContactsList_SelectionChanged(object sender, SelectionChangedEventArgs e)
-        {
-            if (e.AddedItems.Count == 1 && Vm.SelectedThread != e.AddedItems[0])
-            {
-                Vm.WelcomeVisibility = Visibility.Collapsed;
-                Vm.ThreadVisibility = Visibility.Visible;
-                Vm.SelectedThread = (SignalConversation)e.AddedItems[0];
-                ConversationControl.Load(Vm.SelectedThread);
-                SwitchToStyle(GetCurrentViewStyle());
             }
         }
 


### PR DESCRIPTION
This commit
- disables multiwindow on all undesired platforms by restricting Signal-Windows to one window per virtual desktop
- makes clicking the ribbon/starting via the start menu open the window belonging to the current virtual desktop, or open a new one
- makes clicking the notification open the window belonging to the current virtual desktop, or open a new one, and load the corresponding conversation

cc @SERVCUBED @golf1052