### PR TITLE
Add background task to fetch messages

### DIFF
--- a/Signal-Windows.Lib/Events/SignalMessageEventArgs.cs
+++ b/Signal-Windows.Lib/Events/SignalMessageEventArgs.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Signal_Windows.Models;
+
+namespace Signal_Windows.Lib.Events
+{
+    public class SignalMessageEventArgs : EventArgs
+    {
+        public SignalMessage Message { get; private set; }
+
+        public SignalMessageEventArgs(SignalMessage message)
+        {
+            Message = message;
+        }
+    }
+}

--- a/Signal-Windows.Lib/LibUtils.cs
+++ b/Signal-Windows.Lib/LibUtils.cs
@@ -56,7 +56,7 @@ namespace Signal_Windows.Lib
         }
     }
 
-    class LibUtils
+    public class LibUtils
     {
         public const string GlobalSemaphoreName = "SignalWindowsPrivateMessenger_Mutex";
         public static string URL = "https://textsecure-service.whispersystems.org";

--- a/Signal-Windows.Lib/Signal-Windows.Lib.csproj
+++ b/Signal-Windows.Lib/Signal-Windows.Lib.csproj
@@ -106,6 +106,7 @@
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Events\SignalMessageEventArgs.cs" />
     <Compile Include="IncomingMessages.cs" />
     <Compile Include="LibUtils.cs" />
     <Compile Include="Migrations\LibsignalDB\20170806145530_ls1.cs" />
@@ -167,7 +168,11 @@
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.0.1</Version>
     </PackageReference>
+    <PackageReference Include="System.ValueTuple">
+      <Version>4.4.0</Version>
+    </PackageReference>
   </ItemGroup>
+  <ItemGroup />
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>
   </PropertyGroup>

--- a/Signal-Windows.Lib/SignalLibHandle.cs
+++ b/Signal-Windows.Lib/SignalLibHandle.cs
@@ -14,6 +14,7 @@ using libsignalservice.util;
 using System.Collections.Concurrent;
 using libsignal;
 using System.Diagnostics;
+using Signal_Windows.Lib.Events;
 
 namespace Signal_Windows.Lib
 {
@@ -43,6 +44,8 @@ namespace Signal_Windows.Lib
         private SignalServiceMessageSender MessageSender;
         private SignalServiceMessageReceiver MessageReceiver;
         public BlockingCollection<SignalMessage> OutgoingQueue = new BlockingCollection<SignalMessage>(new ConcurrentQueue<SignalMessage>());
+
+        public event EventHandler<SignalMessageEventArgs> SignalMessageEvent;
 
         #region frontend api
         public SignalLibHandle(bool headless)
@@ -128,6 +131,16 @@ namespace Signal_Windows.Lib
             SemaphoreSlim.Release();
         }
 
+        public void BackgroundAcquire()
+        {
+            CancelSource = new CancellationTokenSource();
+            Instance = this;
+            SignalDBContext.FailAllPendingMessages();
+            Store = LibsignalDBContext.GetSignalStore();
+            InitNetwork();
+            Running = true;
+        }
+
         public async Task Reacquire()
         {
             Logger.LogTrace("Reacquire() locking");
@@ -167,6 +180,15 @@ namespace Signal_Windows.Lib
             Logger.LogTrace("Release() releasing (global and local)");
             LibUtils.Unlock();
             SemaphoreSlim.Release();
+        }
+
+        public void BackgroundRelease()
+        {
+            Running = false;
+            CancelSource.Cancel();
+            IncomingMessagesTask?.Wait();
+            OutgoingMessagesTask?.Wait();
+            Instance = null;
         }
 
         public async Task SendMessage(SignalMessage message, SignalConversation conversation)
@@ -254,6 +276,7 @@ namespace Signal_Windows.Lib
                     Frames[dispatcher].HandleMessage(message, conversation);
                 }));
             }
+            SignalMessageEvent?.Invoke(this, new SignalMessageEventArgs(message));
             Task.WaitAll(operations.ToArray());
         }
 

--- a/Signal-Windows.Lib/SignalLogging.cs
+++ b/Signal-Windows.Lib/SignalLogging.cs
@@ -49,7 +49,7 @@ namespace Signal_Windows.Storage
 
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
         {
-            Debug.WriteLine(string.Format("[{0}] [{1}] ", logLevel, ClassName) + formatter(state, exception));
+            Debug.WriteLine(string.Format("{0:s} [{1}] [{2}] ", DateTime.UtcNow, logLevel, ClassName) + formatter(state, exception));
         }
     }
 
@@ -118,7 +118,7 @@ namespace Signal_Windows.Storage
             {
                 try
                 {
-                    Writer.WriteLine($"[{Prefix}] {line}");
+                    Writer.WriteLine($"{DateTime.UtcNow.ToString("s")} [{Prefix}] {line}");
                     Writer.Flush();
                 }
                 catch(Exception e)

--- a/Signal-Windows.RC/Properties/AssemblyInfo.cs
+++ b/Signal-Windows.RC/Properties/AssemblyInfo.cs
@@ -1,0 +1,29 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Signal-Windows.RC")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Signal-Windows.RC")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: ComVisible(false)]

--- a/Signal-Windows.RC/Signal-Windows.RC.csproj
+++ b/Signal-Windows.RC/Signal-Windows.RC.csproj
@@ -1,0 +1,138 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{F8AF07FF-395F-4BF7-84F7-D16EDE7B00DF}</ProjectGuid>
+    <OutputType>winmdobj</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Signal_Windows.RC</RootNamespace>
+    <AssemblyName>Signal-Windows.RC</AssemblyName>
+    <DefaultLanguage>en-US</DefaultLanguage>
+    <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
+    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.16299.0</TargetPlatformVersion>
+    <TargetPlatformMinVersion>10.0.15063.0</TargetPlatformMinVersion>
+    <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <AllowCrossPlatformRetargeting>false</AllowCrossPlatformRetargeting>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+    <PlatformTarget>x86</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x86\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+    <PlatformTarget>x86</PlatformTarget>
+    <OutputPath>bin\x86\Release\</OutputPath>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <Optimize>true</Optimize>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM'">
+    <PlatformTarget>ARM</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\ARM\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>full</DebugType>
+    <PlatformTarget>ARM</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|ARM'">
+    <PlatformTarget>ARM</PlatformTarget>
+    <OutputPath>bin\ARM\Release\</OutputPath>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <Optimize>true</Optimize>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>ARM</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <PlatformTarget>x64</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x64\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <PlatformTarget>x64</PlatformTarget>
+    <OutputPath>bin\x64\Release\</OutputPath>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <Optimize>true</Optimize>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup>
+    <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SignalBackgroundTask.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
+      <Version>6.0.6</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications">
+      <Version>2.1.1</Version>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Signal-Windows.Lib\Signal-Windows.Lib.csproj">
+      <Project>{1934fd82-a5ea-4b71-b915-a1826593cb6e}</Project>
+      <Name>Signal-Windows.Lib</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
+    <VisualStudioVersion>14.0</VisualStudioVersion>
+  </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Signal-Windows.RC/SignalBackgroundTask.cs
+++ b/Signal-Windows.RC/SignalBackgroundTask.cs
@@ -1,0 +1,169 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Toolkit.Uwp.Notifications;
+using Signal_Windows.Lib;
+using Signal_Windows.Lib.Events;
+using Signal_Windows.Models;
+using Windows.ApplicationModel.Background;
+using Windows.UI.Notifications;
+
+namespace Signal_Windows.RC
+{
+    public sealed class SignalBackgroundTask : IBackgroundTask
+    {
+        private const string TaskName = "SignalMessageBackgroundTask";
+        private const string SemaphoreName = "Signal_Windows_Semaphore";
+
+        private BackgroundTaskDeferral deferral;
+
+        private Semaphore semaphore;
+        private DateTime taskStartTime;
+        private DateTime taskEndTime;
+        private SignalLibHandle handle;
+        private ToastNotifier toastNotifier;
+
+        public async void Run(IBackgroundTaskInstance taskInstance)
+        {
+            taskInstance.Canceled += TaskInstance_Canceled;
+            deferral = taskInstance.GetDeferral();
+            toastNotifier = ToastNotificationManager.CreateToastNotifier();
+            ShowNotification("Background task starting");
+            taskStartTime = DateTime.Now;
+            taskEndTime = taskStartTime + TimeSpan.FromSeconds(10);
+            bool appRunning = IsAppRunning();
+            if (appRunning)
+            {
+                ShowNotification("App is running, background task shutting down");
+                deferral.Complete();
+                return;
+            }
+            handle = new SignalLibHandle(true);
+            handle.SignalMessageEvent += Handle_SignalMessageEvent;
+            handle.BackgroundAcquire();
+            await CheckTimer();
+            Shutdown();
+            deferral.Complete();
+        }
+
+        private async Task CheckTimer()
+        {
+            ShowNotification("Started listening for messages");
+            while (true)
+            {
+                if (DateTime.Now >= taskEndTime)
+                {
+                    return;
+                }
+                await Task.Delay(TimeSpan.FromMilliseconds(250));
+            }
+        }
+
+        private void TaskInstance_Canceled(IBackgroundTaskInstance sender, BackgroundTaskCancellationReason reason)
+        {
+            ShowNotification($"Background task cancelled: {reason}");
+            Shutdown();
+            deferral.Complete();
+        }
+
+        private bool IsAppRunning()
+        {
+            semaphore = null;
+            try
+            {
+                semaphore = Semaphore.OpenExisting(LibUtils.GlobalSemaphoreName);
+            }
+            catch (WaitHandleCannotBeOpenedException)
+            {
+                semaphore = new Semaphore(1, 1, LibUtils.GlobalSemaphoreName);
+            }
+
+            bool gotSignal = semaphore.WaitOne(TimeSpan.FromSeconds(5));
+            return !gotSignal;
+        }
+
+        private void Shutdown()
+        {
+            ShowNotification("Background task shutting down");
+            handle.BackgroundRelease();
+            semaphore.Release();
+        }
+
+        private void Handle_SignalMessageEvent(object sender, SignalMessageEventArgs e)
+        {
+            string notificationId = e.Message.ThreadId;
+            ToastBindingGeneric toastBinding = new ToastBindingGeneric();
+
+            var notificationText = GetNotificationText(e.Message.Author.ThreadDisplayName, e.Message.Content.Content);
+            foreach (var item in notificationText)
+            {
+                toastBinding.Children.Add(item);
+            }
+
+            ToastContent toastContent = new ToastContent()
+            {
+                Launch = notificationId,
+                Visual = new ToastVisual()
+                {
+                    BindingGeneric = toastBinding
+                },
+                DisplayTimestamp = DateTimeOffset.FromUnixTimeMilliseconds(e.Message.ReceivedTimestamp)
+            };
+
+            ToastNotification toastNotification = new ToastNotification(toastContent.GetXml());
+            uint expiresIn = e.Message.ExpiresAt;
+            if (expiresIn > 0)
+            {
+                toastNotification.ExpirationTime = DateTime.Now.Add(TimeSpan.FromSeconds(expiresIn));
+            }
+            toastNotification.Tag = notificationId;
+            toastNotifier.Show(toastNotification);
+        }
+
+        private IList<AdaptiveText> GetNotificationText(string authorName, string content)
+        {
+            List<AdaptiveText> text = new List<AdaptiveText>();
+            AdaptiveText title = new AdaptiveText()
+            {
+                Text = authorName,
+                HintMaxLines = 1
+            };
+            AdaptiveText messageText = new AdaptiveText()
+            {
+                Text = content,
+                HintWrap = true
+            };
+            text.Add(title);
+            text.Add(messageText);
+            return text;
+        }
+
+        private void ShowNotification(string content)
+        {
+            ToastContent toastContent = new ToastContent()
+            {
+                Visual = new ToastVisual()
+                {
+                    BindingGeneric = new ToastBindingGeneric()
+                    {
+                        Children =
+                        {
+                            new AdaptiveText()
+                            {
+                                Text = content,
+                                HintWrap = true
+                            }
+                        }
+                    }
+                }
+            };
+
+            ToastNotification toastNotification = new ToastNotification(toastContent.GetXml());
+            toastNotifier.Show(toastNotification);
+        }
+    }
+}

--- a/Signal-Windows.RC/SignalBackgroundTask.cs
+++ b/Signal-Windows.RC/SignalBackgroundTask.cs
@@ -5,10 +5,13 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using libsignalservice;
+using Microsoft.Extensions.Logging;
 using Microsoft.Toolkit.Uwp.Notifications;
 using Signal_Windows.Lib;
 using Signal_Windows.Lib.Events;
 using Signal_Windows.Models;
+using Signal_Windows.Storage;
 using Windows.ApplicationModel.Background;
 using Windows.UI.Notifications;
 
@@ -18,6 +21,8 @@ namespace Signal_Windows.RC
     {
         private const string TaskName = "SignalMessageBackgroundTask";
         private const string SemaphoreName = "Signal_Windows_Semaphore";
+
+        private readonly ILogger Logger = LibsignalLogging.CreateLogger<SignalBackgroundTask>();
 
         private BackgroundTaskDeferral deferral;
 
@@ -29,16 +34,17 @@ namespace Signal_Windows.RC
 
         public async void Run(IBackgroundTaskInstance taskInstance)
         {
+            taskStartTime = DateTime.Now;
+            taskEndTime = taskStartTime + TimeSpan.FromSeconds(25);
             taskInstance.Canceled += TaskInstance_Canceled;
             deferral = taskInstance.GetDeferral();
+            SignalLogging.SetupLogging(false);
             toastNotifier = ToastNotificationManager.CreateToastNotifier();
-            ShowNotification("Background task starting");
-            taskStartTime = DateTime.Now;
-            taskEndTime = taskStartTime + TimeSpan.FromSeconds(10);
+            Logger.LogInformation("Background task starting");
             bool appRunning = IsAppRunning();
             if (appRunning)
             {
-                ShowNotification("App is running, background task shutting down");
+                Logger.LogWarning("App is running, background task shutting down");
                 deferral.Complete();
                 return;
             }
@@ -52,7 +58,7 @@ namespace Signal_Windows.RC
 
         private async Task CheckTimer()
         {
-            ShowNotification("Started listening for messages");
+            Logger.LogInformation("Started listening for messages");
             while (true)
             {
                 if (DateTime.Now >= taskEndTime)
@@ -65,7 +71,7 @@ namespace Signal_Windows.RC
 
         private void TaskInstance_Canceled(IBackgroundTaskInstance sender, BackgroundTaskCancellationReason reason)
         {
-            ShowNotification($"Background task cancelled: {reason}");
+            Logger.LogError($"Background task cancelled: {reason}");
             Shutdown();
             deferral.Complete();
         }
@@ -88,7 +94,7 @@ namespace Signal_Windows.RC
 
         private void Shutdown()
         {
-            ShowNotification("Background task shutting down");
+            Logger.LogInformation("Background task shutting down");
             handle.BackgroundRelease();
             semaphore.Release();
         }
@@ -140,30 +146,6 @@ namespace Signal_Windows.RC
             text.Add(title);
             text.Add(messageText);
             return text;
-        }
-
-        private void ShowNotification(string content)
-        {
-            ToastContent toastContent = new ToastContent()
-            {
-                Visual = new ToastVisual()
-                {
-                    BindingGeneric = new ToastBindingGeneric()
-                    {
-                        Children =
-                        {
-                            new AdaptiveText()
-                            {
-                                Text = content,
-                                HintWrap = true
-                            }
-                        }
-                    }
-                }
-            };
-
-            ToastNotification toastNotification = new ToastNotification(toastContent.GetXml());
-            toastNotifier.Show(toastNotification);
         }
     }
 }

--- a/Signal-Windows.sln
+++ b/Signal-Windows.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.27004.2006
+VisualStudioVersion = 15.0.27130.2020
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Signal-Windows", "Signal-Windows\Signal-Windows.csproj", "{41736A64-5B66-44AF-879A-501192A46920}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -8,6 +8,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Signal-Windows", "Signal-Wi
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Signal-Windows.Lib", "Signal-Windows.Lib\Signal-Windows.Lib.csproj", "{1934FD82-A5EA-4B71-B915-A1826593CB6E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Signal-Windows.RC", "Signal-Windows.RC\Signal-Windows.RC.csproj", "{F8AF07FF-395F-4BF7-84F7-D16EDE7B00DF}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -59,6 +61,22 @@ Global
 		{1934FD82-A5EA-4B71-B915-A1826593CB6E}.Release|x64.Build.0 = Release|x64
 		{1934FD82-A5EA-4B71-B915-A1826593CB6E}.Release|x86.ActiveCfg = Release|x86
 		{1934FD82-A5EA-4B71-B915-A1826593CB6E}.Release|x86.Build.0 = Release|x86
+		{F8AF07FF-395F-4BF7-84F7-D16EDE7B00DF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F8AF07FF-395F-4BF7-84F7-D16EDE7B00DF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F8AF07FF-395F-4BF7-84F7-D16EDE7B00DF}.Debug|ARM.ActiveCfg = Debug|ARM
+		{F8AF07FF-395F-4BF7-84F7-D16EDE7B00DF}.Debug|ARM.Build.0 = Debug|ARM
+		{F8AF07FF-395F-4BF7-84F7-D16EDE7B00DF}.Debug|x64.ActiveCfg = Debug|x64
+		{F8AF07FF-395F-4BF7-84F7-D16EDE7B00DF}.Debug|x64.Build.0 = Debug|x64
+		{F8AF07FF-395F-4BF7-84F7-D16EDE7B00DF}.Debug|x86.ActiveCfg = Debug|x86
+		{F8AF07FF-395F-4BF7-84F7-D16EDE7B00DF}.Debug|x86.Build.0 = Debug|x86
+		{F8AF07FF-395F-4BF7-84F7-D16EDE7B00DF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F8AF07FF-395F-4BF7-84F7-D16EDE7B00DF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F8AF07FF-395F-4BF7-84F7-D16EDE7B00DF}.Release|ARM.ActiveCfg = Release|ARM
+		{F8AF07FF-395F-4BF7-84F7-D16EDE7B00DF}.Release|ARM.Build.0 = Release|ARM
+		{F8AF07FF-395F-4BF7-84F7-D16EDE7B00DF}.Release|x64.ActiveCfg = Release|x64
+		{F8AF07FF-395F-4BF7-84F7-D16EDE7B00DF}.Release|x64.Build.0 = Release|x64
+		{F8AF07FF-395F-4BF7-84F7-D16EDE7B00DF}.Release|x86.ActiveCfg = Release|x86
+		{F8AF07FF-395F-4BF7-84F7-D16EDE7B00DF}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Signal-Windows/App.xaml.cs
+++ b/Signal-Windows/App.xaml.cs
@@ -132,15 +132,15 @@ namespace Signal_Windows
         {
             string taskName = "SignalMessageBackgroundTask";
             bool foundTask = false;
-            BackgroundExecutionManager.RemoveAccess();
-            foreach (var task in BackgroundTaskRegistration.AllTasks)
-            {
-                if (task.Value.Name == taskName)
-                {
-                    backgroundTaskRegistration = task.Value;
-                    foundTask = true;
-                }
-            }
+            BackgroundExecutionManager.RemoveAccess("2383BenediktRadtke.SignalPrivateMessenger");
+            //foreach (var task in BackgroundTaskRegistration.AllTasks)
+            //{
+            //    if (task.Value.Name == taskName)
+            //    {
+            //        backgroundTaskRegistration = task.Value;
+            //        foundTask = true;
+            //    }
+            //}
 
             if (!foundTask)
             {
@@ -149,8 +149,8 @@ namespace Signal_Windows
                 builder.TaskEntryPoint = "Signal_Windows.RC.SignalBackgroundTask";
                 builder.IsNetworkRequested = true;
                 builder.SetTrigger(new TimeTrigger(15, false));
-                builder.SetTrigger(new SystemTrigger(SystemTriggerType.ServicingComplete, false));
-                builder.SetTrigger(new SystemTrigger(SystemTriggerType.TimeZoneChange, false));
+                //builder.SetTrigger(new SystemTrigger(SystemTriggerType.ServicingComplete, false));
+                //builder.SetTrigger(new SystemTrigger(SystemTriggerType.TimeZoneChange, false));
                 builder.AddCondition(new SystemCondition(SystemConditionType.InternetAvailable));
                 var requestStatus = await BackgroundExecutionManager.RequestAccessAsync();
                 if (requestStatus != BackgroundAccessStatus.DeniedBySystemPolicy ||

--- a/Signal-Windows/Package.appxmanifest
+++ b/Signal-Windows/Package.appxmanifest
@@ -21,21 +21,22 @@
         <uap:SplashScreen Image="Assets\SplashScreen.png" BackgroundColor="#2090EA" />
       </uap:VisualElements>
       <Extensions>
-        <Extension Category="windows.backgroundTasks" EntryPoint="Signal_Windows.RC.SignalBackgroundTask">
-          <BackgroundTasks>
-            <Task Type="systemEvent" />
-          </BackgroundTasks>
-        </Extension>
-        <uap:Extension Category="windows.protocol">
-          <uap:Protocol Name="ms-contact-profile">
-            <uap:DisplayName>Signal Private Messenger Contact</uap:DisplayName>
-          </uap:Protocol>
-        </uap:Extension>
         <uap:Extension Category="windows.protocol">
           <uap:Protocol Name="ms-ipmessaging">
             <uap:DisplayName>Signal Private Messenger Message</uap:DisplayName>
           </uap:Protocol>
         </uap:Extension>
+        <uap:Extension Category="windows.protocol">
+          <uap:Protocol Name="ms-contact-profile">
+            <uap:DisplayName>Signal Private Messenger Contact</uap:DisplayName>
+          </uap:Protocol>
+        </uap:Extension>
+        <Extension Category="windows.backgroundTasks" EntryPoint="Signal_Windows.RC.SignalBackgroundTask">
+          <BackgroundTasks>
+            <Task Type="systemEvent" />
+            <Task Type="timer" />
+          </BackgroundTasks>
+        </Extension>
       </Extensions>
     </Application>
   </Applications>

--- a/Signal-Windows/Package.appxmanifest
+++ b/Signal-Windows/Package.appxmanifest
@@ -21,14 +21,19 @@
         <uap:SplashScreen Image="Assets\SplashScreen.png" BackgroundColor="#2090EA" />
       </uap:VisualElements>
       <Extensions>
-        <uap:Extension Category="windows.protocol">
-          <uap:Protocol Name="ms-ipmessaging">
-            <uap:DisplayName>Signal Private Messenger Message</uap:DisplayName>
-          </uap:Protocol>
-        </uap:Extension>
+        <Extension Category="windows.backgroundTasks" EntryPoint="Signal_Windows.RC.SignalBackgroundTask">
+          <BackgroundTasks>
+            <Task Type="systemEvent" />
+          </BackgroundTasks>
+        </Extension>
         <uap:Extension Category="windows.protocol">
           <uap:Protocol Name="ms-contact-profile">
             <uap:DisplayName>Signal Private Messenger Contact</uap:DisplayName>
+          </uap:Protocol>
+        </uap:Extension>
+        <uap:Extension Category="windows.protocol">
+          <uap:Protocol Name="ms-ipmessaging">
+            <uap:DisplayName>Signal Private Messenger Message</uap:DisplayName>
           </uap:Protocol>
         </uap:Extension>
       </Extensions>

--- a/Signal-Windows/Signal-Windows.csproj
+++ b/Signal-Windows/Signal-Windows.csproj
@@ -288,7 +288,7 @@
       <Version>6.0.4</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications">
-      <Version>1.5.1</Version>
+      <Version>2.1.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Uwp.UI.Controls">
       <Version>2.0.0</Version>
@@ -313,6 +313,10 @@
     <ProjectReference Include="..\Signal-Windows.Lib\Signal-Windows.Lib.csproj">
       <Project>{1934fd82-a5ea-4b71-b915-a1826593cb6e}</Project>
       <Name>Signal-Windows.Lib</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Signal-Windows.RC\Signal-Windows.RC.csproj">
+      <Project>{f8af07ff-395f-4bf7-84f7-d16ede7b00df}</Project>
+      <Name>Signal-Windows.RC</Name>
     </ProjectReference>
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">

--- a/Signal-Windows/ViewModels/FinishRegistrationPageViewModel.cs
+++ b/Signal-Windows/ViewModels/FinishRegistrationPageViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;

--- a/Signal-Windows/ViewModels/LinkPageViewModel.cs
+++ b/Signal-Windows/ViewModels/LinkPageViewModel.cs
@@ -114,6 +114,7 @@ namespace Signal_Windows.ViewModels
                     {
                         UIEnabled = false;
                         App.Store = store;
+                        SignalLibHandle.Instance.Store = store;
                     }).AsTask().Wait();
 
                     /* create prekeys */


### PR DESCRIPTION
Background task launches every 15 minutes to fetch any new messages. Currently stays up for ~25 seconds before shutting down as Windows kills background tasks after 30 seconds of runtime.

Added logging to background task and logs now show timestamp as well.

Did some git magic to get this to rebase correctly

@Trolldemorted 