### PR TITLE
while suspended the cache may become stale, so drop it when resuming

### DIFF
--- a/Signal-Windows.Lib/SignalLibHandle.cs
+++ b/Signal-Windows.Lib/SignalLibHandle.cs
@@ -147,6 +147,7 @@ namespace Signal_Windows.Lib
             CancelSource = new CancellationTokenSource();
             SemaphoreSlim.Wait(CancelSource.Token);
             LibUtils.Lock();
+            LibsignalDBContext.ClearSessionCache();
             Instance = this;
             await Task.Run(() =>
             {


### PR DESCRIPTION
I think dropping it in reacquire should be enough

cc @golf1052 