### PR TITLE
introduce ISignalLibHandle, add basic attachment methods

### DIFF
--- a/Signal-Windows.Lib/SignalLibHandle.cs
+++ b/Signal-Windows.Lib/SignalLibHandle.cs
@@ -26,12 +26,46 @@ namespace Signal_Windows.Lib
         void HandleMessageUpdate(SignalMessage updatedMessage);
         void ReplaceConversationList(List<SignalConversation> conversations);
         void HandleAuthFailure();
+        void HandleAttachmentStatusChanged(SignalAttachment sa, SignalAttachmentStatus newStatus);
     }
 
-    public class SignalLibHandle
+    public interface ISignalLibHandle
     {
-        public static SignalLibHandle Instance;
-        public SignalStore Store;
+        //Frontend API
+        SignalStore Store { get; set; }
+        Task SendMessage(SignalMessage message, SignalConversation conversation);
+        void ResendMessage(SignalMessage message);
+        List<SignalMessageContainer> GetMessages(SignalConversation thread, int startIndex, int count);
+        void SaveAndDispatchSignalConversation(SignalConversation updatedConversation, SignalMessage updateMessage);
+        void PurgeAccountData();
+        Task Acquire(CoreDispatcher d, ISignalFrontend w);
+        Task Reacquire();
+        void Release();
+        void AddFrontend(CoreDispatcher d, ISignalFrontend w);
+        void RemoveFrontend(CoreDispatcher d);
+
+        // Background API
+        event EventHandler<SignalMessageEventArgs> SignalMessageEvent;
+        void BackgroundAcquire();
+        void BackgroundRelease();
+
+        // Attachment API
+        void StartAttachmentDownload(SignalAttachment sa);
+        //void AbortAttachmentDownload(SignalAttachment sa); TODO
+    }
+
+    public static class SignalHelper
+    {
+        public static ISignalLibHandle CreateSignalLibHandle(bool headless)
+        {
+            return new SignalLibHandle(headless);
+        }
+    }
+
+    internal class SignalLibHandle : ISignalLibHandle
+    {
+        internal static SignalLibHandle Instance;
+        public SignalStore Store { get; set; }
         private readonly ILogger Logger = LibsignalLogging.CreateLogger<SignalLibHandle>();
         public SemaphoreSlim SemaphoreSlim = new SemaphoreSlim(1, 1);
         private bool Headless;
@@ -206,6 +240,11 @@ namespace Signal_Windows.Lib
             });
         }
 
+        public void ResendMessage(SignalMessage message)
+        {
+            OutgoingQueue.Add(message);
+        }
+
         public List<SignalMessageContainer> GetMessages(SignalConversation thread, int startIndex, int count)
         {
             return SignalDBContext.GetMessagesLocked(thread, startIndex, count);
@@ -222,7 +261,14 @@ namespace Signal_Windows.Lib
         }
         #endregion
 
-        #region backend api
+        #region attachment api
+        public void StartAttachmentDownload(SignalAttachment sa)
+        {
+            //TODO lock, check if already downloading, start a new download if not exists
+        }
+        #endregion
+
+        #region internal api
         internal void SaveAndDispatchSignalMessage(SignalMessage message, SignalConversation conversation)
         {
             conversation.MessagesCount += 1;

--- a/Signal-Windows.RC/SignalBackgroundTask.cs
+++ b/Signal-Windows.RC/SignalBackgroundTask.cs
@@ -29,7 +29,7 @@ namespace Signal_Windows.RC
         private Semaphore semaphore;
         private DateTime taskStartTime;
         private DateTime taskEndTime;
-        private SignalLibHandle handle;
+        private ISignalLibHandle handle;
         private ToastNotifier toastNotifier;
 
         public async void Run(IBackgroundTaskInstance taskInstance)
@@ -48,7 +48,7 @@ namespace Signal_Windows.RC
                 deferral.Complete();
                 return;
             }
-            handle = new SignalLibHandle(true);
+            handle = SignalHelper.CreateSignalLibHandle(true);
             handle.SignalMessageEvent += Handle_SignalMessageEvent;
             handle.BackgroundAcquire();
             await CheckTimer();

--- a/Signal-Windows/App.xaml.cs
+++ b/Signal-Windows/App.xaml.cs
@@ -39,7 +39,7 @@ namespace Signal_Windows
         public static bool MainPageActive = false;
         public static string USER_AGENT = "Signal-Windows";
         public static uint PREKEY_BATCH_SIZE = 100;
-        public static SignalLibHandle Handle = new SignalLibHandle(false);
+        public static ISignalLibHandle Handle = SignalHelper.CreateSignalLibHandle(false);
         private Dictionary<int, SignalWindowsFrontend> Views = new Dictionary<int, SignalWindowsFrontend>();
         public static int MainViewId;
         private IBackgroundTaskRegistration backgroundTaskRegistration;

--- a/Signal-Windows/Controls/Message.xaml.cs
+++ b/Signal-Windows/Controls/Message.xaml.cs
@@ -103,7 +103,7 @@ namespace Signal_Windows.Controls
 
         private void ResendTextBlock_Tapped(object sender, Windows.UI.Xaml.Input.TappedRoutedEventArgs e)
         {
-            App.Handle.OutgoingQueue.Add(Model.Message);
+            App.Handle.ResendMessage(Model.Message);
         }
 
         internal bool HandleUpdate(SignalMessage updatedMessage)

--- a/Signal-Windows/SignalWindowsFrontend.cs
+++ b/Signal-Windows/SignalWindowsFrontend.cs
@@ -48,5 +48,10 @@ namespace Signal_Windows
         {
             // TODO
         }
+
+        public void HandleAttachmentStatusChanged(SignalAttachment sa, SignalAttachmentStatus status)
+        {
+            //TODO
+        }
     }
 }

--- a/Signal-Windows/ViewModels/FinishRegistrationPageViewModel.cs
+++ b/Signal-Windows/ViewModels/FinishRegistrationPageViewModel.cs
@@ -46,7 +46,7 @@ namespace Signal_Windows.ViewModels
                     Windows.ApplicationModel.Core.CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, () =>
                     {
                         App.Store = store;
-                        SignalLibHandle.Instance.Store = store;
+                        App.Handle.Store = store;
                     }).AsTask().Wait();
 
                     /* create prekeys */

--- a/Signal-Windows/ViewModels/LinkPageViewModel.cs
+++ b/Signal-Windows/ViewModels/LinkPageViewModel.cs
@@ -114,7 +114,7 @@ namespace Signal_Windows.ViewModels
                     {
                         UIEnabled = false;
                         App.Store = store;
-                        SignalLibHandle.Instance.Store = store;
+                        App.Handle.Store = store;
                     }).AsTask().Wait();
 
                     /* create prekeys */
@@ -125,7 +125,7 @@ namespace Signal_Windows.ViewModels
                     Windows.ApplicationModel.Core.CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, () =>
                     {
                         App.Store = store;
-                        SignalLibHandle.Instance.Store = store;
+                        App.Handle.Store = store;
                         View.Finish(true);
                     }).AsTask().Wait();
                 });

--- a/Signal-Windows/ViewModels/MainPageViewModel.cs
+++ b/Signal-Windows/ViewModels/MainPageViewModel.cs
@@ -102,7 +102,7 @@ namespace Signal_Windows.ViewModels
                         Read = true,
                         Type = SignalMessageType.Normal
                     };
-                    await SignalLibHandle.Instance.SendMessage(message, SelectedThread);
+                    await App.Handle.SendMessage(message, SelectedThread);
                     Debug.WriteLine("keydown lock released");
                 }
                 return true;


### PR DESCRIPTION
Currently receive-attachments downloads attachments in the MPVM, which won't work if the conversation is open in multiple windows.

This commit adds the `ISignalLibHandle` interface and reduces the visibility of `SignalLibHandle` to internal. This way we introduce a clear separation between frontend and backend.

Frontends shall call `StartAttachmentDownload` to start an attachment download, and shall be notified by `HandleAttachmentStatusChanged`.

We should be able to rebase 6ef61f95adb0baf9855f03e2ce59b1e45dade592 on top of this without major changes, shouldn't we?

cc @golf1052  @SERVCUBED 