### PR TITLE
new_conversation_fix

### DIFF
--- a/Signal-Windows.Lib/IncomingMessages.cs
+++ b/Signal-Windows.Lib/IncomingMessages.cs
@@ -377,7 +377,9 @@ namespace Signal_Windows.Lib
                         Group = group,
                         Timestamp = Util.CurrentTimeMillis()
                     };
-                    //MessageSender.sendMessage(envelope.getSourceAddress(), requestInfoMessage); TODO
+                    var list = new List<SignalServiceAddress>();
+                    list.Add(new SignalServiceAddress(envelope.getSource()));
+                    SignalLibHandle.Instance.OutgoingMessages.SendMessage(list, requestInfoMessage);
                 }
                 composedTimestamp = envelope.getTimestamp();
             }

--- a/Signal-Windows.Lib/OutgoingMessages.cs
+++ b/Signal-Windows.Lib/OutgoingMessages.cs
@@ -32,6 +32,14 @@ namespace Signal_Windows.Lib
             Handle = handle;
         }
 
+        public void SendMessage(List<SignalServiceAddress> recipients, SignalServiceDataMessage message)
+        {
+            lock (this)
+            {
+                MessageSender.sendMessage(recipients, message);
+            }
+        }
+
         public void HandleOutgoingMessages()
         {
             Logger.LogDebug("HandleOutgoingMessages()");
@@ -74,7 +82,7 @@ namespace Signal_Windows.Lib
                         };
                         if (!Token.IsCancellationRequested)
                         {
-                            MessageSender.sendMessage(recipients, message);
+                            SendMessage(recipients, message);
                             outgoingSignalMessage.Status = SignalMessageStatus.Confirmed;
                         }
                     }

--- a/Signal-Windows.Lib/SignalLibHandle.cs
+++ b/Signal-Windows.Lib/SignalLibHandle.cs
@@ -40,6 +40,7 @@ namespace Signal_Windows.Lib
         private Dictionary<CoreDispatcher, ISignalFrontend> Frames = new Dictionary<CoreDispatcher, ISignalFrontend>();
         private Task IncomingMessagesTask;
         private Task OutgoingMessagesTask;
+        internal OutgoingMessages OutgoingMessages;
         private SignalServiceMessagePipe Pipe;
         private SignalServiceMessageSender MessageSender;
         private SignalServiceMessageReceiver MessageReceiver;
@@ -381,7 +382,8 @@ namespace Signal_Windows.Lib
             Pipe = MessageReceiver.createMessagePipe();
             MessageSender = new SignalServiceMessageSender(CancelSource.Token, LibUtils.ServiceUrls, Store.Username, Store.Password, (int)Store.DeviceId, new Store(), Pipe, null, LibUtils.USER_AGENT);
             IncomingMessagesTask = Task.Factory.StartNew(() => new IncomingMessages(CancelSource.Token, Pipe, this).HandleIncomingMessages(), TaskCreationOptions.LongRunning);
-            OutgoingMessagesTask = Task.Factory.StartNew(() => new OutgoingMessages(CancelSource.Token, MessageSender, this).HandleOutgoingMessages(), TaskCreationOptions.LongRunning);
+            OutgoingMessages = new OutgoingMessages(CancelSource.Token, MessageSender, this);
+            OutgoingMessagesTask = Task.Factory.StartNew(() => OutgoingMessages.HandleOutgoingMessages(), TaskCreationOptions.LongRunning);
         }
         #endregion
     }

--- a/Signal-Windows.Lib/Storage/DB.cs
+++ b/Signal-Windows.Lib/Storage/DB.cs
@@ -958,9 +958,10 @@ namespace Signal_Windows.Storage
 
         #region Groups
 
-        public static SignalGroup GetOrCreateGroupLocked(string groupId, long timestamp)
+        public static SignalGroup GetOrCreateGroupLocked(string groupId, long timestamp, bool notify = true)
         {
             SignalGroup dbgroup;
+            bool createdNew = false;
             lock (DBLock)
             {
                 using (var ctx = new SignalDBContext())
@@ -984,8 +985,13 @@ namespace Signal_Windows.Storage
                         };
                         ctx.Add(dbgroup);
                         ctx.SaveChanges();
+                        createdNew = true;
                     }
                 }
+            }
+            if (createdNew && notify)
+            {
+                SignalLibHandle.Instance.DispatchAddOrUpdateConversation(dbgroup, null);
             }
             return dbgroup;
         }
@@ -1087,9 +1093,10 @@ namespace Signal_Windows.Storage
             }
         }
 
-        public static SignalContact GetOrCreateContactLocked(string username, long timestamp)
+        public static SignalContact GetOrCreateContactLocked(string username, long timestamp, bool notify = true)
         {
             SignalContact contact;
+            bool createdNew = false;
             lock (DBLock)
             {
                 using (var ctx = new SignalDBContext())
@@ -1109,8 +1116,13 @@ namespace Signal_Windows.Storage
                         };
                         ctx.Contacts.Add(contact);
                         ctx.SaveChanges();
+                        createdNew = true;
                     }
                 }
+            }
+            if (createdNew && notify)
+            {
+                SignalLibHandle.Instance.DispatchAddOrUpdateConversation(contact, null);
             }
             return contact;
         }


### PR DESCRIPTION
signal-windows did crash when a msg from a new conversation arrived, because the new inserted conversation was not dispatched to the views.