### PR TITLE
fix message read log message, only attempt to mark a message read once per view

### DIFF
--- a/Signal-Windows.Lib/SignalLibHandle.cs
+++ b/Signal-Windows.Lib/SignalLibHandle.cs
@@ -344,7 +344,7 @@ namespace Signal_Windows.Lib
             finally
             {
                 SemaphoreSlim.Release();
-                Logger.LogTrace("SendMessage() released");
+                Logger.LogTrace("SetMessageRead() released");
             }
         }
 

--- a/Signal-Windows/Controls/Conversation.xaml.cs
+++ b/Signal-Windows/Controls/Conversation.xaml.cs
@@ -34,6 +34,7 @@ namespace Signal_Windows.Controls
         private Dictionary<long, SignalAttachmentContainer> UnfinishedAttachmentsCache = new Dictionary<long, SignalAttachmentContainer>();
         private SignalConversation SignalConversation;
         public VirtualizedCollection Collection;
+        private int LastMarkReadRequest;
 
         private string _ThreadDisplayName;
 
@@ -135,6 +136,7 @@ namespace Signal_Windows.Controls
         public void Load(SignalConversation conversation)
         {
             SignalConversation = conversation;
+            LastMarkReadRequest = -1;
             InputTextBox.IsEnabled = false;
             DisposeCurrentThread();
             UpdateHeader(conversation);
@@ -319,9 +321,11 @@ namespace Signal_Windows.Controls
         private void ScrollViewer_ViewChanged(object sender, ScrollViewerViewChangedEventArgs e)
         {
             int bottomIndex = GetBottommostIndex();
-            if (Window.Current.CoreWindow.ActivationMode == CoreWindowActivationMode.ActivatedInForeground
-                && SignalConversation.LastSeenMessageIndex < bottomIndex)
+            if (Window.Current.CoreWindow.ActivationMode == CoreWindowActivationMode.ActivatedInForeground &&
+                SignalConversation.LastSeenMessageIndex < bottomIndex &&
+                LastMarkReadRequest < bottomIndex)
             {
+                LastMarkReadRequest = bottomIndex;
                 Task.Run(() =>
                 {
                     App.Handle.SetMessageRead(bottomIndex, SignalConversation);


### PR DESCRIPTION
The scrollviewer's view changed event may be thrown multiple times while the same element remains at the bottom.

It is obviously unneccessary to call `SetMessageRead` in these cases, so we should keep track of the last marked message for each conversation.