### PR TITLE
Allow multiline input

### DIFF
--- a/Signal-Windows/Controls/Conversation.xaml
+++ b/Signal-Windows/Controls/Conversation.xaml
@@ -132,7 +132,7 @@
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
-            <TextBox Grid.Column="0" Name="InputTextBox" VerticalAlignment="Center" KeyDown="TextBox_KeyDown" PlaceholderText="Type a message" BorderBrush="{x:Null}" BorderThickness="0" TextWrapping="Wrap" TextChanged="InputTextBox_TextChanged" InputScope="Chat" Visibility="{x:Bind SendMessageVisible, Mode=OneWay}"/>
+            <TextBox Grid.Column="0" PreviewKeyDown="TextBox_PreviewKeyDown" Name="InputTextBox" VerticalAlignment="Center" PlaceholderText="Type a message" BorderBrush="{x:Null}" BorderThickness="0" TextWrapping="Wrap" TextChanged="InputTextBox_TextChanged" InputScope="Chat" Visibility="{x:Bind SendMessageVisible, Mode=OneWay}" AcceptsReturn="true"/>
             <Button x:Name="SendMessageButton" Grid.Column="1" Click="SendMessageButton_Click" IsEnabled="{x:Bind SendButtonEnabled, Mode=OneWay}" Background="{x:Bind SendButtonBackground}" VerticalAlignment="Bottom" Width="50" VerticalContentAlignment="Stretch" MinHeight="50" Visibility="{x:Bind SendMessageVisible, Mode=OneWay}">
                 <SymbolIcon Symbol="Send"/>
             </Button>

--- a/Signal-Windows/ViewModels/MainPageViewModel.cs
+++ b/Signal-Windows/ViewModels/MainPageViewModel.cs
@@ -87,14 +87,14 @@ namespace Signal_Windows.ViewModels
             set { _ThreadListAlignRight = value; RaisePropertyChanged(nameof(ThreadListAlignRight)); }
         }
 
-        private async Task<bool> SendMessage(string messageText)
+        internal async Task<bool> SendMessage(string messageText)
         {
-            Debug.WriteLine("starting sendmessage");
             try
             {
                 if (!string.IsNullOrEmpty(messageText))
                 {
                     var now = Util.CurrentTimeMillis();
+                    messageText = messageText.Replace("\r", "\r\n");
                     SignalMessage message = new SignalMessage()
                     {
                         Author = null,
@@ -142,11 +142,6 @@ namespace Signal_Windows.ViewModels
                     break;
                 }
             }
-        }
-
-        internal async Task<bool> SendMessageButton_Click(string text)
-        {
-            return await SendMessage(text.Replace("\r", "\r\n"));
         }
 
         internal void Deselect()


### PR DESCRIPTION
Allow multiline input for our input text box!

Works fine on W10 1803 desktops, could somebody test it on W10M? I am not certain whether `PreviewKeyDown` is supported, and I don't know what happens if you attach a keyboard to a w10m device (I assume that is possible?).

Removed the anti double-send workaround as the uwp bug appears to be fixed.