### PR TITLE
Allow multiline input, disable send button focus

### DIFF
--- a/Signal-Windows/Controls/Conversation.xaml
+++ b/Signal-Windows/Controls/Conversation.xaml
@@ -126,7 +126,7 @@
             <Button x:Name="SendMessageButton" Grid.Column="1" Click="SendMessageButton_Click" IsEnabled="{x:Bind SendButtonEnabled, Mode=OneWay}" Background="{x:Bind SendButtonBackground}" VerticalAlignment="Bottom" Width="50" VerticalContentAlignment="Stretch" MinHeight="50" Visibility="{x:Bind SendMessageVisible, Mode=OneWay}">
                 <SymbolIcon Symbol="Send"/>
             </Button>
-            <Button x:Name="UnblockButton" Content="Unblock" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Grid.ColumnSpan="2" Height="50" Visibility="{x:Bind Blocked, Mode=OneWay}" Click="UnblockButton_Click"/>
+            <Button x:Name="UnblockButton" Content="Unblock" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Grid.ColumnSpan="2" Height="50" Visibility="{x:Bind Blocked, Mode=OneWay}" Click="UnblockButton_Click" AllowFocusOnInteraction="False"/>
         </Grid>
     </Grid>
 </UserControl>

--- a/Signal-Windows/ViewModels/MainPageViewModel.cs
+++ b/Signal-Windows/ViewModels/MainPageViewModel.cs
@@ -88,13 +88,14 @@ namespace Signal_Windows.ViewModels
             set { _ThreadListAlignRight = value; RaisePropertyChanged(nameof(ThreadListAlignRight)); }
         }
 
-        private async Task<bool> SendMessage(string messageText)
+        internal async Task<bool> SendMessage(string messageText)
         {
             try
             {
                 if (!string.IsNullOrEmpty(messageText))
                 {
                     var now = Util.CurrentTimeMillis();
+                    messageText = messageText.Replace("\r", "\r\n");
                     SignalMessage message = new SignalMessage()
                     {
                         Author = null,
@@ -142,11 +143,6 @@ namespace Signal_Windows.ViewModels
                     break;
                 }
             }
-        }
-
-        internal async Task<bool> SendMessageButton_Click(string text)
-        {
-            return await SendMessage(text.Replace("\r", "\r\n"));
         }
 
         internal void Deselect()


### PR DESCRIPTION
Allow multiline input for our input text box, attempt 2!

Works fine on W10 1803 desktops, could somebody test it on W10M? No PreviewKeyDown this time!

I have also set `AllowFocusOnInteraction="False"` for the send button, this should keep the cursor in the input text field (at least it does on w10 1803).

fixes #155, closes #160