### PR TITLE
Maintain bottommost position when the conversation is resized

### DIFF
--- a/Signal-Windows/Controls/Conversation.xaml
+++ b/Signal-Windows/Controls/Conversation.xaml
@@ -110,7 +110,7 @@
                 </Button>
             </Grid>
         </Border>
-        <ListView Style="{StaticResource ConversationStyle}" Grid.Row="1" Name="ConversationItemsControl" VirtualizingStackPanel.VirtualizationMode="Recycling" Background="White" ScrollViewer.VerticalScrollBarVisibility="Visible" Padding="0 0 15 0" SelectionMode="None">
+        <ListView Style="{StaticResource ConversationStyle}" Grid.Row="1" Name="ConversationItemsControl" VirtualizingStackPanel.VirtualizationMode="Recycling" Background="White" ScrollViewer.VerticalScrollBarVisibility="Visible" Padding="0 0 15 0" SelectionMode="None" SizeChanged="ConversationItemsControl_SizeChanged">
             <ListView.ItemContainerStyle>
                 <Style TargetType="ListViewItem">
                     <Setter Property="HorizontalContentAlignment" Value="Stretch" />

--- a/Signal-Windows/Controls/Conversation.xaml.cs
+++ b/Signal-Windows/Controls/Conversation.xaml.cs
@@ -324,6 +324,31 @@ namespace Signal_Windows.Controls
             SendButtonEnabled = t.Text != string.Empty;
         }
 
+        private static ScrollViewer GetScrollViewer(DependencyObject element)
+        {
+            if (element is ScrollViewer)
+            {
+                return (ScrollViewer)element;
+            }
+
+            for (int i = 0; i < VisualTreeHelper.GetChildrenCount(element); i++)
+            {
+                var child = VisualTreeHelper.GetChild(element, i);
+
+                var result = GetScrollViewer(child);
+                if (result == null)
+                {
+                    continue;
+                }
+                else
+                {
+                    return result;
+                }
+            }
+
+            return null;
+        }
+
         private void ScrollToUnread()
         {
             if (Collection.Count > 0)
@@ -402,6 +427,19 @@ namespace Signal_Windows.Controls
                 {
                     App.Handle.SendBlockedMessage();
                 });
+            }
+        }
+
+        private void ConversationItemsControl_SizeChanged(object sender, SizeChangedEventArgs e)
+        {
+            var scrollbar = GetScrollViewer(this);
+            if (scrollbar != null)
+            {
+                var verticalDelta = e.PreviousSize.Height - e.NewSize.Height;
+                if (verticalDelta > 0)
+                {
+                    scrollbar.ChangeView(null, scrollbar.VerticalOffset + verticalDelta, null);
+                }
             }
         }
     }


### PR DESCRIPTION
Otherwise the bottommost message is moved out of sight if
- the entire window is resized
- the input text box grows (cc #170), so the available space for the conversation shrinks