### PR TITLE
Improved extension handling when saving attachment

### DIFF
--- a/Signal-Windows.Lib/SignalLibHandle.cs
+++ b/Signal-Windows.Lib/SignalLibHandle.cs
@@ -530,6 +530,11 @@ namespace Signal_Windows.Lib
                     SuggestedStartLocation = Windows.Storage.Pickers.PickerLocationId.Downloads,
                     SuggestedFileName = sa.SentFileName ?? "signal"
                 };
+                string extension = Path.GetExtension(savePicker.SuggestedFileName);
+                if (!string.IsNullOrWhiteSpace(extension))
+                {
+                    savePicker.FileTypeChoices.Add(extension.TrimStart('.').ToUpper(), new List<string>() { extension });
+                }
                 savePicker.FileTypeChoices.Add("Any", new List<string>() { "." });
                 var target_file = await savePicker.PickSaveFileAsync();
                 if (target_file != null)


### PR DESCRIPTION
If SuggestedFileName has an extension then add an additional FileTypeChoice for this extension and use this choice as default.

The reason I fixed this is because it did not work on mobile for some reason. `target_file` was always `null`.