### PR TITLE
Improved formatting of last message in ConversationListElement

### DIFF
--- a/Signal-Windows/Controls/ConversationListElement.xaml
+++ b/Signal-Windows/Controls/ConversationListElement.xaml
@@ -38,7 +38,9 @@
                     <ColumnDefinition Width="*"/>
                     <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
-                <TextBlock Grid.Column="0" Text="{x:Bind LastMessage, Mode=OneWay}" Visibility="{x:Bind LastMessageVisibility, Mode=OneWay}" FontSize="12"/>
+                <TextBlock Grid.Column="0" Text="{x:Bind LastMessage, Mode=OneWay}"
+                           Visibility="{x:Bind LastMessageVisibility, Mode=OneWay}"
+                           FontSize="12" MaxLines="2" TextWrapping="WrapWholeWords" TextTrimming="CharacterEllipsis"/>
                 <Grid Grid.Column="1" Margin="10 0 0 0">
                     <Ellipse Fill="#2190EA" Visibility="{x:Bind UnreadStringVisibility, Mode=OneWay}" Width="20" Height="20"/>
                     <TextBlock Text="{x:Bind UnreadString, Mode=TwoWay}" Visibility="{x:Bind UnreadStringVisibility, Mode=OneWay}" FontWeight="Bold" FontSize="12" Foreground="White" HorizontalAlignment="Center" VerticalAlignment="Center"/>


### PR DESCRIPTION
- Limits the count of lines of the last message of a chat that are displayed in the chat preview to 2 lines. Currently, are all lines displayed, which can take a lot of space. I think a limit of 2 lines is enough but 3 or 4 wouldn't hurt. What do you think?
- Added TextWrapping for long lines

## Examples

### Desktop
Before:
![desktop_old](https://user-images.githubusercontent.com/42971547/119351590-ef450800-bca0-11eb-8491-b8356321eb66.jpg)

Now:
![desktop_new](https://user-images.githubusercontent.com/42971547/119351628-f9ff9d00-bca0-11eb-9edc-3863185aca8a.jpg)

### Mobile
Before:
![mobile_old](https://user-images.githubusercontent.com/42971547/119351787-2d422c00-bca1-11eb-893c-b324f44979e8.jpg)

Now:
![mobile_new](https://user-images.githubusercontent.com/42971547/119351806-316e4980-bca1-11eb-83be-8ccee0128fe3.jpg)

### Message Text
```
This is the first line
This is the second line and it is much longer which results in a line break
This is the third line
4
5
6
7
8
9
```
